### PR TITLE
Document direct downloading of debs

### DIFF
--- a/docs/common-mistakes/deb-download-archive.rst
+++ b/docs/common-mistakes/deb-download-archive.rst
@@ -1,48 +1,60 @@
 Direct downloading of .debs from the archive
 ############################################
 
-While sourcing a :file:`.deb` file directly from the Ubuntu Archive website
-is significantly safer than using an untrusted source, this installation method
-still circumvents the management and verification processes provided by the
-standard ``apt`` tool. The ``apt`` ecosystem is designed to handle more than 
-just the download of software; it manages dependencies, verifies package integrity,
-and ensures seamless integration into the system's update cycle. Opting to download
-and install a file manually bypasses these critical safeguards, introducing some 
-risks that are detailed below.
+While it may be tempting to download a :file:`.deb` file directly from the
+Ubuntu Archive website, this installation method circumvents the management
+and verification processes provided by the standard APT tool. The APT 
+ecosystem is designed to handle more than just the download of software; it
+manages dependencies, verifies package integrity, and ensures seamless 
+integration into the system's update cycle. Opting to download and install a
+file manually bypasses these critical safeguards, introducing some risks that 
+are detailed below.
 
 Lack of integrity verification
 ==============================
 
-The ``apt`` package management system uses a cryptographic chain of trust to
-ensure that software is authentic and has not been altered. Repository metadata
-is digitally signed with Ubuntu's official GPG keys, and this metadata contains
-checksums for every individual package. When using ``apt``, the integrity of a
-downloaded :file:`.deb` is always verified against these trusted checksums before
+The APT package management system uses a cryptographic chain of trust to
+ensure that software is authentic and has not been altered. More information
+about this scheme can be found :doc:`here <../software-integrity/archive-verification>`.
+Repository metadata is digitally signed with Ubuntu's official GPG keys,
+and this metadata contains the cryptographic hash for every individual package.
+When using APT, the integrity of a downloaded :file:`.deb` is always verified
+up to the trust anchor against these trusted cryptographic hashes before 
 installation begins.
 
-A :file:`.deb` file downloaded directly through a web browser completely bypasses
-this integrity check. While HTTPS provides encryption for the connection, it does
-not verify the file's authenticity against the repository's chain of trust. This
-leaves an opening for machine-in-the-middle (MitM) attacks where an attacker could
-serve a modified, malicious package. Without the integrity verification performed
-by ``apt``, you have no guarantee that the file you downloaded is the one you
-intended to download.
+A :file:`.deb` file downloaded directly through a web browser or HTTP client 
+completely bypasses this integrity check. While HTTPS provides encryption and 
+integrity protection that reduce tampering-related risks when the archive 
+integrity verification scheme is employed, it does not verify the file's
+authenticity against the repository's chain of trust. This leaves an opening
+for machine-in-the-middle (MitM) attacks where an attacker could serve a
+modified, malicious package.
 
-To guarantee package authenticity and prevent tampering, software should always be
-installed via package managers such as ``apt`` that perform cryptographic
+To package integrity protection and prevent tampering, software should always be
+installed via package managers such as APT that perform cryptographic
 verification.
 
-No automatic security updates
-=============================
+Missed security updates
+=======================
 
-Normally, when installing software from Ubuntu's official repositories, that 
-software will automatically receive security patches and updates through the 
-standard ``apt`` update process (contingent on the Ubuntu release being under
-active support, learn more `here <https://ubuntu.com/about/release-cycle>`_).
-If a standalone :file:`.deb` is installed instead, this automatic security
-and update process is completely bypassed. Updates need to be manually applied,
-potentially leaving a system vulnerable to exploitation.
+Software installed from Ubuntu's official repositories is managed by the APT
+package manager, which ensures it receives timely security patches. When you
+manually install a :file:`.deb` file, you risk missing these crucial updates
+in a couple of common ways.
+
+For example, if the software you installed is not available in any of your 
+configured repositories, the APT package manager has no way to check for or
+apply new versions. You become solely responsible for manually tracking, 
+downloading, and installing any future security patches.
+
+Additionally, there may be instances where you might download a package from
+a newer Ubuntu release or a testing repository. This package will have a 
+higher version number than the one in the official repositories for your
+current release. Because the installed version number is higher, the update 
+process will not replace it to apply a security patch to the officially
+supported version, effectively pinning your system to the manually installed,
+unpatched software.
 
 To ensure you have the most secure version of software, it is highly recommended
-to source :file:`.deb` files from trusted sources and avenues that offer 
-automatic security updates.
+to source :file:`.deb` files via configuring APT sources and installing packages
+through APT frontends.

--- a/docs/common-mistakes/deb-download-archive.rst
+++ b/docs/common-mistakes/deb-download-archive.rst
@@ -1,0 +1,48 @@
+Direct downloading of .debs from the archive
+############################################
+
+While sourcing a :file:`.deb` file directly from the Ubuntu Archive website
+is significantly safer than using an untrusted source, this installation method
+still circumvents the management and verification processes provided by the
+standard ``apt`` tool. The ``apt`` ecosystem is designed to handle more than 
+just the download of software; it manages dependencies, verifies package integrity,
+and ensures seamless integration into the system's update cycle. Opting to download
+and install a file manually bypasses these critical safeguards, introducing some 
+risks that are detailed below.
+
+Lack of integrity verification
+==============================
+
+The ``apt`` package management system uses a cryptographic chain of trust to
+ensure that software is authentic and has not been altered. Repository metadata
+is digitally signed with Ubuntu's official GPG keys, and this metadata contains
+checksums for every individual package. When using ``apt``, the integrity of a
+downloaded :file:`.deb` is always verified against these trusted checksums before
+installation begins.
+
+A :file:`.deb` file downloaded directly through a web browser completely bypasses
+this integrity check. While HTTPS provides encryption for the connection, it does
+not verify the file's authenticity against the repository's chain of trust. This
+leaves an opening for machine-in-the-middle (MitM) attacks where an attacker could
+serve a modified, malicious package. Without the integrity verification performed
+by ``apt``, you have no guarantee that the file you downloaded is the one you
+intended to download.
+
+To guarantee package authenticity and prevent tampering, software should always be
+installed via package managers such as ``apt`` that perform cryptographic
+verification.
+
+No automatic security updates
+=============================
+
+Normally, when installing software from Ubuntu's official repositories, that 
+software will automatically receive security patches and updates through the 
+standard ``apt`` update process (contingent on the Ubuntu release being under
+active support, learn more `here <https://ubuntu.com/about/release-cycle>`_).
+If a standalone :file:`.deb` is installed instead, this automatic security
+and update process is completely bypassed. Updates need to be manually applied,
+potentially leaving a system vulnerable to exploitation.
+
+To ensure you have the most secure version of software, it is highly recommended
+to source :file:`.deb` files from trusted sources and avenues that offer 
+automatic security updates.

--- a/docs/common-mistakes/deb-download-archive.rst
+++ b/docs/common-mistakes/deb-download-archive.rst
@@ -1,60 +1,28 @@
 Direct downloading of .debs from the archive
 ############################################
 
-While it may be tempting to download a :file:`.deb` file directly from the
-Ubuntu Archive website, this installation method circumvents the management
-and verification processes provided by the standard APT tool. The APT 
-ecosystem is designed to handle more than just the download of software; it
-manages dependencies, verifies package integrity, and ensures seamless 
-integration into the system's update cycle. Opting to download and install a
-file manually bypasses these critical safeguards, introducing some risks that 
-are detailed below.
+You can download a :file:`.deb` package directly from the Ubuntu Archive website without using the APT manager. However, APT provides critical security features: it manages dependencies, verifies package integrity, and ensures integration with the system’s update mechanism.
+
+By downloading :file:`.deb` packages directly, you bypass these protections and introduce security risks.
 
 Lack of integrity verification
 ==============================
 
-The APT package management system uses a cryptographic chain of trust to
-ensure that software is authentic and has not been altered. More information
-about this scheme can be found :doc:`here <../software-integrity/archive-verification>`.
-Repository metadata is digitally signed with Ubuntu's official GPG keys,
-and this metadata contains the cryptographic hash for every individual package.
-When using APT, the integrity of a downloaded :file:`.deb` is always verified
-up to the trust anchor against these trusted cryptographic hashes before 
-installation begins.
+APT uses a cryptographic chain of trust to ensure software is authentic and unaltered. Repository metadata is digitally signed with Ubuntu’s official GPG keys and includes a cryptographic hash for every package. When you install a package through APT, it verifies the package against these trusted hashes before installation.
 
-A :file:`.deb` file downloaded directly through a web browser or HTTP client 
-completely bypasses this integrity check. While HTTPS provides encryption and 
-integrity protection that reduce tampering-related risks when the archive 
-integrity verification scheme is employed, it does not verify the file's
-authenticity against the repository's chain of trust. This leaves an opening
-for machine-in-the-middle (MitM) attacks where an attacker could serve a
-modified, malicious package.
+See more in :doc:`Ubuntu archive integrity verification <../software-integrity/archive-verification>`.
 
-To package integrity protection and prevent tampering, software should always be
-installed via package managers such as APT that perform cryptographic
-verification.
+By downloading :file:`.deb` packages manually through a web browser or HTTP client, you bypass this verification process. While HTTPS reduces the risk of tampering by providing encryption and basic integrity protection, it does not validate the file against the repository’s cryptographic signatures. This leaves an opening for machine-in-the-middle (MitM) attacks where an attacker could serve a modified package.
 
-Missed security updates
-=======================
+To ensure package authenticity and prevent tampering, always install software through a package manager like APT, which performs full cryptographic verification.
 
-Software installed from Ubuntu's official repositories is managed by the APT
-package manager, which ensures it receives timely security patches. When you
-manually install a :file:`.deb` file, you risk missing these crucial updates
-in a couple of common ways.
+Missed or blocked security updates 
+=================================
 
-For example, if the software you installed is not available in any of your 
-configured repositories, the APT package manager has no way to check for or
-apply new versions. You become solely responsible for manually tracking, 
-downloading, and installing any future security patches.
+Installing :file:`.deb` packages manually bypasses APT’s automatic security updates.
 
-Additionally, there may be instances where you might download a package from
-a newer Ubuntu release or a testing repository. This package will have a 
-higher version number than the one in the official repositories for your
-current release. Because the installed version number is higher, the update 
-process will not replace it to apply a security patch to the officially
-supported version, effectively pinning your system to the manually installed,
-unpatched software.
+If the manually installed package is not included in your configured repositories, APT will not check for or apply updates. You must manually track, download, and install any future security patches.
 
-To ensure you have the most secure version of software, it is highly recommended
-to source :file:`.deb` files via configuring APT sources and installing packages
-through APT frontends.
+If the manually installed package comes from a newer Ubuntu release or a testing repository, it can block future security patches. Such packages may have a higher version number than in your current release. As a result, APT will not replace them with the officially supported version, even if a security update is available. This can leave your system pinned to an unpatched version.
+
+To receive timely security updates, configure the appropriate APT sources and install packages using APT.

--- a/docs/common-mistakes/deb-download-untrusted.rst
+++ b/docs/common-mistakes/deb-download-untrusted.rst
@@ -1,32 +1,32 @@
-Direct downloading of .debs from untrusted sources
-##################################################
+Downloading .debs from untrusted sources
+########################################
 
-While :file:`.deb` files offer a convenient method to package and distribute 
-software, this ease of distribution inherently comes with risks. As an example, 
+While packages offer a convenient method to package and distribute software, 
+this ease of distribution inherently comes with risks. As an example, 
 consider a scenario where a user has provided a direct download link for a 
-:file:`.deb` file on a public forum. Downloading and installing this file from
-such a source is **discouraged** for several reasons.
+package on a public forum. Downloading and installing this package from such
+a source is **discouraged** for several reasons.
 
 
 Lack of security verification
 =============================
 
 Unlike software sourced from Ubuntu's official repositories (e.g., the Ubuntu
-Archive), which includes packages vetted by the Ubuntu Security team, a :file:`.deb`
-file originating from an untrusted source, like a public forum, has likely undergone
-no security screening. This lack of verification means that bad actors may have
-made modifications to the software contained within the :file:`.deb` file. 
+Archive), which includes packages vetted by the Ubuntu Security team, a package
+file originating from an untrusted source, like a public forum, has likely 
+undergone no security screening. This lack of verification means that bad 
+actors may have made modifications to the software contained within the package. 
 
-When possible, always source :file:`.deb` files from trusted sources and not from 
-untrusted sources like public forums.
+When possible, always source packages from trusted sources and not from untrusted
+sources like public forums.
 
 
 Potential for malware
 =====================
 
-Installing a :file:`.deb` file to make software available system-wide almost always
-requires ``root`` privileges. If a bad actor has modified a :file:`.deb` file for
-malicious reasons, providing ``root`` privileges can elevate the risk that malware,
+Installing a package to make software available system-wide almost always requires
+``root`` privileges. If a bad actor has modified a :file:`.deb` file for malicious
+reasons, providing ``root`` privileges can elevate the risk that malware,
 ransomware, spyware, or keyloggers are installed on your system. 
 
 Whenever running a command with ``root`` privileges, always ensure you know what
@@ -39,11 +39,11 @@ System instability and dependency issues
 
 Software retrieved from trusted sources, such as the Ubuntu Archive, has been built
 and tested to work seamlessly with other packages that may already be present on
-a given system. In contrast, a :file:`.deb` file from an unknown or untrusted 
-source might have been built for a different version of Ubuntu or have conflicting
-dependencies. The installation of such a :file:`.deb` can cause system instability
-due to these conflicts, which in the worst case can render a system unusable. 
+a given system. In contrast, a package from an unknown or untrusted source might
+have been built for a different version of Ubuntu or have conflicting dependencies.
+The installation of such a :file:`.deb` can cause system instability due to these
+conflicts, which in the worst case can render a system unusable. 
 
 To avoid dependency issues and to ensure system stability, it is always best to 
-retrieve and install :file:`.deb` files from trusted sources, like Ubuntu's
-official repositories.
+retrieve and install packages from trusted sources, like Ubuntu's official 
+repositories.

--- a/docs/common-mistakes/deb-download-untrusted.rst
+++ b/docs/common-mistakes/deb-download-untrusted.rst
@@ -1,19 +1,15 @@
-Direct downloading of .debs
-###########################
+Direct downloading of .debs from untrusted sources
+##################################################
 
-A :file:`.deb` file, also known as a Debian package, is an archive that contains all
-of the necessary files and information needed to install and run a piece of 
-software. Ubuntu provides support for :file:`.deb` files, alongside snaps, Flatpaks,
-and AppImages.
+While :file:`.deb` files offer a convenient method to package and distribute 
+software, this ease of distribution inherently comes with risks. As an example, 
+consider a scenario where a user has provided a direct download link for a 
+:file:`.deb` file on a public forum. Downloading and installing this file from
+such a source is **discouraged** for several reasons.
 
-While :file:`.deb` files offer a convenient method to package and distribute software,
-this ease of distribution inherently comes with risks. As an example, consider a
-scenario where a user has provided a direct download link for a :file:`.deb` 
-file on a public forum. Downloading and installing this file from such a source
-is **discouraged** for several reasons.
 
-Lack of verification
-====================
+Lack of security verification
+=============================
 
 Unlike software sourced from Ubuntu's official repositories (e.g., the Ubuntu
 Archive), which includes packages vetted by the Ubuntu Security team, a :file:`.deb`
@@ -51,19 +47,3 @@ due to these conflicts, which in the worst case can render a system unusable.
 To avoid dependency issues and to ensure system stability, it is always best to 
 retrieve and install :file:`.deb` files from trusted sources, like Ubuntu's
 official repositories.
-
-
-No automatic security updates
-=============================
-
-Whenever installing software from Ubuntu's official repositories, that software will
-automatically receive security patches and updates through the standard ``apt``
-update process (contingent on the Ubuntu release being under active support, learn 
-more `here <https://ubuntu.com/about/release-cycle>`_). If a standalone :file:`.deb`
-is installed instead, this automatic security and update process is completely
-bypassed. Updates need to be manually applied, potentially leaving a system 
-vulnerable to exploitation.
-
-To ensure you have the most secure version of software, it is highly recommended 
-to source :file:`.deb` files from trusted sources that offer update paths through
-the standard ``apt`` update process.

--- a/docs/common-mistakes/direct-deb-download-overview.rst
+++ b/docs/common-mistakes/direct-deb-download-overview.rst
@@ -9,8 +9,8 @@ and AppImages.
 While :file:`.deb` files offer a convenient method to package and distribute software,
 this ease of distribution inherently comes with risks. As an example, consider a
 scenario where a user has provided a direct download link for a :file:`.deb` 
-file on a public forum. Downloading and installing such a file is **discouraged**
-for several reasons.
+file on a public forum. Downloading and installing this file from such a source
+is **discouraged** for several reasons.
 
 Lack of verification
 ====================
@@ -58,7 +58,7 @@ No automatic security updates
 
 Whenever installing software from Ubuntu's official repositories, that software will
 automatically receive security patches and updates through the standard ``apt``
-update process (contigent on the Ubuntu release being under active support (learn 
+update process (contigent on the Ubuntu release being under active support, learn 
 more `here <https://ubuntu.com/about/release-cycle>`_). If a standalone :file:`.deb`
 is installed instead, this automatic security and update process is completely
 bypassed. Updates need to be manually applied, potentially leaving a system 

--- a/docs/common-mistakes/direct-deb-download-overview.rst
+++ b/docs/common-mistakes/direct-deb-download-overview.rst
@@ -1,7 +1,7 @@
 Direct downloading of .debs
 ###########################
 
-A :file:`.deb` file, as known as a Debian package, is an archive that contains all
+A :file:`.deb` file, also known as a Debian package, is an archive that contains all
 of the necessary files and information needed to install and run a piece of 
 software. Ubuntu provides support for :file:`.deb` files, alongside snaps, Flatpaks,
 and AppImages.
@@ -17,7 +17,7 @@ Lack of verification
 
 Unlike software sourced from Ubuntu's official repositories (e.g., the Ubuntu
 Archive), which includes packages vetted by the Ubuntu Security team, a :file:`.deb`
-file originating from an untrusted source like a public forum has likely undergone
+file originating from an untrusted source, like a public forum, has likely undergone
 no security screening. This lack of verification means that bad actors may have
 made modifications to the software contained within the :file:`.deb` file. 
 
@@ -29,12 +29,12 @@ Potential for malware
 =====================
 
 Installing a :file:`.deb` file to make software available system-wide almost always
-require ``root`` privileges. If a bad actor has modified a :file:`.deb` file for
+requires ``root`` privileges. If a bad actor has modified a :file:`.deb` file for
 malicious reasons, providing ``root`` privileges can elevate the risk that malware,
-ransomware, spyware, or keyloggers are installed to your system. 
+ransomware, spyware, or keyloggers are installed on your system. 
 
 Whenever running a command with ``root`` privileges, always ensure you know what
-the command is going to do and that the inputs you are passing come from trusted
+the command is going to do, and that the inputs you are passing come from trusted
 sources.
 
 
@@ -58,7 +58,7 @@ No automatic security updates
 
 Whenever installing software from Ubuntu's official repositories, that software will
 automatically receive security patches and updates through the standard ``apt``
-update process (contigent on the Ubuntu release being under active support, learn 
+update process (contingent on the Ubuntu release being under active support, learn 
 more `here <https://ubuntu.com/about/release-cycle>`_). If a standalone :file:`.deb`
 is installed instead, this automatic security and update process is completely
 bypassed. Updates need to be manually applied, potentially leaving a system 

--- a/docs/common-mistakes/direct-deb-download-overview.rst
+++ b/docs/common-mistakes/direct-deb-download-overview.rst
@@ -1,0 +1,69 @@
+Direct downloading of .debs
+###########################
+
+A :file:`.deb` file, as known as a Debian package, is an archive that contains all
+of the necessary files and information needed to install and run a piece of 
+software. Ubuntu provides support for :file:`.deb` files, alongside snaps, Flatpaks,
+and AppImages.
+
+While :file:`.deb` files offer a convenient method to package and distribute software,
+this ease of distribution inherently comes with risks. As an example, consider a
+scenario where a user has provided a direct download link for a :file:`.deb` 
+file on a public forum. Downloading and installing such a file is **discouraged**
+for several reasons.
+
+Lack of verification
+====================
+
+Unlike software sourced from Ubuntu's official repositories (e.g., the Ubuntu
+Archive), which includes packages vetted by the Ubuntu Security team, a :file:`.deb`
+file originating from an untrusted source like a public forum has likely undergone
+no security screening. This lack of verification means that bad actors may have
+made modifications to the software contained within the :file:`.deb` file. 
+
+When possible, always source :file:`.deb` files from trusted sources and not from 
+untrusted sources like public forums.
+
+
+Potential for malware
+=====================
+
+Installing a :file:`.deb` file to make software available system-wide almost always
+require ``root`` privileges. If a bad actor has modified a :file:`.deb` file for
+malicious reasons, providing ``root`` privileges can elevate the risk that malware,
+ransomware, spyware, or keyloggers are installed to your system. 
+
+Whenever running a command with ``root`` privileges, always ensure you know what
+the command is going to do and that the inputs you are passing come from trusted
+sources.
+
+
+System instability and dependency issues
+========================================
+
+Software retrieved from trusted sources, such as the Ubuntu Archive, has been built
+and tested to work seamlessly with other packages that may already be present on
+a given system. In contrast, a :file:`.deb` file from an unknown or untrusted 
+source might have been built for a different version of Ubuntu or have conflicting
+dependencies. The installation of such a :file:`.deb` can cause system instability
+due to these conflicts, which in the worst case can render a system unusable. 
+
+To avoid dependency issues and to ensure system stability, it is always best to 
+retrieve and install :file:`.deb` files from trusted sources, like Ubuntu's
+official repositories.
+
+
+No automatic security updates
+=============================
+
+Whenever installing software from Ubuntu's official repositories, that software will
+automatically receive security patches and updates through the standard ``apt``
+update process (contigent on the Ubuntu release being under active support (learn 
+more `here <https://ubuntu.com/about/release-cycle>`_). If a standalone :file:`.deb`
+is installed instead, this automatic security and update process is completely
+bypassed. Updates need to be manually applied, potentially leaving a system 
+vulnerable to exploitation.
+
+To ensure you have the most secure version of software, it is highly recommended 
+to source :file:`.deb` files from trusted sources that offer update paths through
+the standard ``apt`` update process.

--- a/docs/common-mistakes/index.rst
+++ b/docs/common-mistakes/index.rst
@@ -3,8 +3,8 @@ Common security mistakes
 
 Direct downloading of .debs
 ===========================
-
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
+   :glob:
 
-   direct-deb-download-overview
+   *

--- a/docs/common-mistakes/index.rst
+++ b/docs/common-mistakes/index.rst
@@ -1,0 +1,10 @@
+Common security mistakes
+########################
+
+Direct downloading of .debs
+===========================
+
+.. toctree::
+   :maxdepth: 2
+
+   direct-deb-download-overview

--- a/index.rst
+++ b/index.rst
@@ -31,6 +31,13 @@ In this documentation
 
         Make your system compliant.
 
+.. grid:: 2
+    :gutter: 1
+
+    .. grid-item-card:: :ref:`Common security mistakes`
+
+        Learn about common security mistakes and how to avoid them.
+
 Project and community
 =====================
 
@@ -47,7 +54,7 @@ Project and community
    docs/security-updates/index
    docs/security-features/index
    docs/compliance/index
-
+   docs/common-mistakes/index
 
 
   


### PR DESCRIPTION
#### Overview
This PR adds documentation covering the risks associated with directly downloading .debs from untrusted or unknown sources. The following pages have been added/modified:

- `docs/common-mistakes/direct-deb-download-overview.rst`
  - Details what a .deb file is, alongside the risks and drawbacks associated with downloading a .deb from an untrusted or unknown source. These risks include:
    - Lack of security verification
    - Potential for malware
    - System instability and dependency issues
    - No automatic security updates
- `docs/common-mistakes/index.rst`
  - Created a basic index for the new `Common security mistakes` category.
- `index.rst`
  - Modified to include a reference card to the new `Common security mistakes` category. This will be populated with additional items as the documentation pulse continues.