### PR TITLE
Document CPU Features

### DIFF
--- a/docs/security-features/platform-protections/cpu.rst
+++ b/docs/security-features/platform-protections/cpu.rst
@@ -144,8 +144,8 @@ If this exists, then check if the kernel mentions the BIOS after loading the kvm
 
     dmesg | grep "kvm: disabled by bios"
 
-On Ubuntu 9.10 Karmic Koala and later, you can check if your hardware is expected to have
-VT available by running the following command from the ``qemu-kvm`` package:
+You can check if your hardware is expected to have VT available by running the following
+command from the ``qemu-kvm`` package:
 
 .. code-block:: shell
 


### PR DESCRIPTION
#### Overview
This PR adds documentation covering four CPU features supported by Ubuntu that may require users to manually enable them before they can be used. The following pages have been added/modified:

- `docs/security-features/cpu/index.rst`
  - Standard index page covering content migrated from https://wiki.ubuntu.com/Security/CPUFeatures
- `docs/security-features/cpu/cpu-non-exec.rst`
  - Covers content migrated from https://wiki.ubuntu.com/Security/CPUFeatures
- `docs/security-features/cpu/cpu-virt.rst`
  - Covers content migrated from https://wiki.ubuntu.com/Security/CPUFeatures
- `docs/security-features/cpu/cpu-sev.rst`
  - Covers information about AMD Secure Encrypted Virtualization, largely sourced from information located [here](https://www.amd.com/en/developer/sev.html) (we also link to that page if users want more information).
- `docs/security-features/cpu/cpu-tdx.rst`
  - Covers information about Intel Trust Domain Extensions, largely sourced from information located [here](https://www.intel.com/content/www/us/en/developer/tools/trust-domain-extensions/overview.html) (we also link to that page if users want more information).