### PR TITLE
Add Ubuntu Pro subscription hyperlink

### DIFF
--- a/docs/compliance/fips/how-to-install-ubuntu-with-fips.rst
+++ b/docs/compliance/fips/how-to-install-ubuntu-with-fips.rst
@@ -1,7 +1,7 @@
 How to install Ubuntu with FIPS mode enabled
 ============================================
 
-FIPS requires an Ubuntu Pro token, which you can get here - Ubuntu Pro is available for free for up to 5 machines and only requires an email address to sign up.
+FIPS requires an Ubuntu Pro token, which you can get `here <https://ubuntu.com/pro/subscribe>`_ - Ubuntu Pro is available for free for up to 5 machines and only requires an email address to sign up.
 
 .. code-block:: bash
 

--- a/docs/compliance/fips/how-to-switch-ubuntu-to-fips.rst
+++ b/docs/compliance/fips/how-to-switch-ubuntu-to-fips.rst
@@ -1,7 +1,7 @@
 How to switch Ubuntu to FIPS mode
 =================================
 
-FIPS requires an Ubuntu Pro token, which you can get here - Ubuntu Pro is available for free for up to 5 machines and only requires an email address to sign up.
+FIPS requires an Ubuntu Pro token, which you can get `here <https://ubuntu.com/pro/subscribe>`_ - Ubuntu Pro is available for free for up to 5 machines and only requires an email address to sign up.
 
 .. code-block:: bash
 


### PR DESCRIPTION
Add Ubuntu Pro subscription hyperlink in FIPS pages.

Closes #51.