### PR TITLE
Add high-level structure of Fail2ban configuration guide

### DIFF
--- a/security-features/network/fail2ban.rst
+++ b/security-features/network/fail2ban.rst
@@ -1,0 +1,34 @@
+Configure Fail2ban on Ubuntu
+=============================
+
+Install, configure, and troubleshoot Fail2ban on Ubuntu 24.04 LTS.
+
+Prerequisites
+-------------
+
+List of what is required before starting.
+
+Install Fail2ban
+----------------
+
+Fail2ban installation and service setup.
+
+Configure Fail2ban global settings
+-----------------------------------
+
+UFW integration, bantime, maxretry, findtime, whitelisting.
+
+Configure jails
+---------------
+
+SSH, Apache/Nginx, port scanning.
+
+Test configuration
+-----------------------
+
+Trigger the bans to test they are working as supposed.
+
+Troubleshoot common issues
+---------------------------
+
+False positives, bans not triggering, checking ban status.


### PR DESCRIPTION
This PR adds a high-level structure for a Fail2ban configuration guide as suggested by @lucistanescu in issue #86.

Type: Structural (new document)