### PR TITLE
Update security features pages for resolute and stonking

### DIFF
--- a/scripts/features.json
+++ b/scripts/features.json
@@ -160,7 +160,9 @@
       },
       {
         "releases": [
-          "questing"
+          "questing",
+          "resolute",
+          "stonking"
         ],
         "comment": "5.0.0",
         "state": "DEFAULT"
@@ -226,7 +228,9 @@
           "noble",
           "oracular",
           "plucky",
-          "questing"
+          "questing",
+          "resolute",
+          "stonking"
         ],
         "comment": "kernel & userspace",
         "state": "DEFAULT"
@@ -267,7 +271,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -314,7 +320,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -362,7 +370,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -403,7 +413,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -440,6 +452,8 @@
           "oracular",
           "plucky",
           "questing",
+          "resolute",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -484,7 +498,9 @@
           "jammy",
           "noble",
           "plucky",
-          "questing"
+          "questing",
+          "resolute",
+          "stonking"
         ],
         "comment": "LUKS + TPM",
         "state": "DEFAULT"
@@ -516,7 +532,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -600,7 +618,9 @@
           "noble",
           "oracular",
           "plucky",
-          "questing"
+          "questing",
+          "resolute",
+          "stonking"
         ],
         "comment": "ZFS dataset encryption available, encrypted Home (eCryptfs) and ext4 encryption (fscrypt) available in universe",
         "state": "AVAILABLE"
@@ -657,7 +677,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -703,7 +725,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -766,7 +790,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -852,7 +878,9 @@
           "noble",
           "oracular",
           "plucky",
-          "questing"
+          "questing",
+          "resolute",
+          "stonking"
         ],
         "comment": "yescrypt",
         "state": "DEFAULT"
@@ -882,6 +910,8 @@
           "oracular",
           "plucky",
           "questing",
+          "resolute",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -912,7 +942,9 @@
           "noble",
           "oracular",
           "plucky",
-          "questing"
+          "questing",
+          "resolute",
+          "stonking"
         ],
         "comment": "policy",
         "state": "DEFAULT"
@@ -953,7 +985,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -996,7 +1030,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -1035,7 +1071,9 @@
           "noble",
           "oracular",
           "plucky",
-          "questing"
+          "questing",
+          "resolute",
+          "stonking"
         ],
         "comment": "kernel & sysctl",
         "state": "DEFAULT"
@@ -1067,7 +1105,9 @@
           "noble",
           "oracular",
           "plucky",
-          "questing"
+          "questing",
+          "resolute",
+          "stonking"
         ],
         "comment": "kernel & sysctl",
         "state": "DEFAULT"
@@ -1111,7 +1151,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -1163,7 +1205,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -1211,7 +1255,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -1263,7 +1309,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -1311,7 +1359,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -1368,7 +1418,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -1422,7 +1474,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -1477,7 +1531,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -1514,6 +1570,8 @@
           "oracular",
           "plucky",
           "questing",
+          "resolute",
+          "stonking",
           "yakkety",
           "zesty"
         ],
@@ -1583,7 +1641,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -1630,7 +1690,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -1667,6 +1729,8 @@
           "oracular",
           "plucky",
           "questing",
+          "resolute",
+          "stonking",
           "yakkety",
           "zesty"
         ],
@@ -1719,7 +1783,9 @@
           "noble",
           "oracular",
           "plucky",
-          "questing"
+          "questing",
+          "resolute",
+          "stonking"
         ],
         "comment": "gcc patch (i386, amd64, ppc64el, s390x)",
         "state": "DEFAULT"
@@ -1744,7 +1810,9 @@
           "noble",
           "oracular",
           "plucky",
-          "questing"
+          "questing",
+          "resolute",
+          "stonking"
         ],
         "comment": "gcc patch (i386, amd64)",
         "state": "DEFAULT"
@@ -1782,7 +1850,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -1842,7 +1912,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -1892,7 +1964,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -1938,7 +2012,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -1994,7 +2070,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -2044,7 +2122,9 @@
           "noble",
           "oracular",
           "plucky",
-          "questing"
+          "questing",
+          "resolute",
+          "stonking"
         ],
         "comment": "integrity only, no confidentiality",
         "state": "DEFAULT"
@@ -2084,7 +2164,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -2136,7 +2218,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -2202,7 +2286,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -2248,7 +2334,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -2290,7 +2378,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -2332,7 +2422,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -2375,7 +2467,9 @@
           "noble",
           "oracular",
           "plucky",
-          "questing"
+          "questing",
+          "resolute",
+          "stonking"
         ],
         "comment": "kernel (i386, amd64, arm64, and s390 only)",
         "state": "DEFAULT"
@@ -2427,7 +2521,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -2480,7 +2576,9 @@
           "noble",
           "oracular",
           "plucky",
-          "questing"
+          "questing",
+          "resolute",
+          "stonking"
         ],
         "comment": "kernel",
         "state": "DEFAULT"
@@ -2510,6 +2608,8 @@
           "oracular",
           "plucky",
           "questing",
+          "resolute",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -2567,7 +2667,9 @@
           "noble",
           "oracular",
           "plucky",
-          "questing"
+          "questing",
+          "resolute",
+          "stonking"
         ],
         "comment": "amd64, kernel signature enforcement",
         "state": "DEFAULT"
@@ -2597,6 +2699,8 @@
           "oracular",
           "plucky",
           "questing",
+          "resolute",
+          "stonking",
           "xenial",
           "yakkety",
           "zesty"
@@ -2627,7 +2731,9 @@
           "noble",
           "oracular",
           "plucky",
-          "questing"
+          "questing",
+          "resolute",
+          "stonking"
         ],
         "comment": "kernel & userspace",
         "state": "AVAILABLE"
@@ -2655,7 +2761,9 @@
           "noble",
           "oracular",
           "plucky",
-          "questing"
+          "questing",
+          "resolute",
+          "stonking"
         ],
         "comment": "kernel & userspace",
         "state": "DEFAULT"
@@ -2683,7 +2791,9 @@
           "noble",
           "oracular",
           "plucky",
-          "questing"
+          "questing",
+          "resolute",
+          "stonking"
         ],
         "comment": "kernel & userspace",
         "state": "AVAILABLE"
@@ -2725,7 +2835,9 @@
           "quantal",
           "questing",
           "raring",
+          "resolute",
           "saucy",
+          "stonking",
           "trusty",
           "utopic",
           "vivid",
@@ -2763,6 +2875,9 @@
           "groovy",
           "kinetic",
           "oracular",
+          "plucky",
+          "questing",
+          "stonking",
           "utopic",
           "yakkety"
         ],
@@ -2788,6 +2903,13 @@
           "noble"
         ],
         "comment": "24.04 LTS Kernel",
+        "state": "AVAILABLE"
+      },
+      {
+        "releases": [
+          "resolute"
+        ],
+        "comment": "26.04 LTS Kernel",
         "state": "AVAILABLE"
       },
       {
@@ -2829,6 +2951,8 @@
           "oracular",
           "plucky",
           "questing",
+          "resolute",
+          "stonking",
           "xenial",
           "yakkety",
           "zesty"

--- a/scripts/features.json
+++ b/scripts/features.json
@@ -138,8 +138,7 @@
       {
         "releases": [
           "oracular",
-          "plucky",
-          "questing"
+          "plucky"
         ],
         "comment": "4.1.0",
         "state": "DEFAULT"
@@ -157,6 +156,13 @@
           "raring"
         ],
         "comment": "2.8.0",
+        "state": "DEFAULT"
+      },
+      {
+        "releases": [
+          "questing"
+        ],
+        "comment": "5.0.0",
         "state": "DEFAULT"
       },
       {

--- a/scripts/releases.json
+++ b/scripts/releases.json
@@ -242,11 +242,21 @@
     {
         "code_name": "plucky",
         "human_name": "Ubuntu 25.04",
-        "is_eol": false
+        "is_eol": true
     },
     {
         "code_name": "questing",
         "human_name": "Ubuntu 25.10",
+        "is_eol": false
+    },
+    {
+        "code_name": "resolute",
+        "human_name": "Ubuntu 26.04 LTS",
+        "is_eol": false
+    },
+    {
+        "code_name": "stonking",
+        "human_name": "Ubuntu 26.10",
         "is_eol": false
     }
 ]

--- a/scripts/update-features.py
+++ b/scripts/update-features.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Canonical, Ltd.
+# Author: Edwin Jiang <edwin.jiang@canonical.com>
+# License: GPLv3
+
+import argparse
+import json
+import logging
+import sys
+from bisect import insort
+
+PROGRAM_NAME = "update-features"
+
+logger = logging.getLogger(PROGRAM_NAME)
+PROGRAM_DESCRIPTION = """
+For a given release code name, attempt to add it to a change group for each
+feature in features.json.  If the release is missing from a feature, it is
+appended to the same change group as the preceding release (according to
+release order in releases.json).  features.json is modified in place.
+"""
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog=PROGRAM_NAME,
+        description=PROGRAM_DESCRIPTION,
+    )
+    parser.add_argument(
+        "release",
+        help="The release code name to add (e.g. 'questing')",
+    )
+    parser.add_argument(
+        "-r",
+        "--releases",
+        help='Path to releases.json (default: "releases.json")',
+        default="releases.json",
+    )
+    parser.add_argument(
+        "-f",
+        "--features",
+        help='Path to features.json (default: "features.json")',
+        default="features.json",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        help="Enable verbose logging (INFO level)",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-d",
+        "--debug",
+        help="Enable debug logging (DEBUG level)",
+        action="store_true",
+    )
+    return parser.parse_args()
+
+
+def load_json(path: str):
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def save_json(path: str, data):
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2, ensure_ascii=False)
+
+
+def setup_logging(args: argparse.Namespace) -> None:
+    if args.debug:
+        level = logging.DEBUG
+    elif args.verbose:
+        level = logging.INFO
+    else:
+        level = logging.WARNING
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(logging.Formatter("%(name)s: %(levelname)s: %(message)s"))
+    logger.setLevel(level)
+    logger.addHandler(handler)
+
+
+def main() -> None:
+    args = parse_arguments()
+    setup_logging(args)
+
+    logger.debug("Loading releases from %s", args.releases)
+    releases = load_json(args.releases)
+    code_names = [r["code_name"] for r in releases]
+
+    if args.release not in code_names:
+        logger.error("Release '%s' not found in %s", args.release, args.releases)
+        sys.exit(1)
+
+    release_idx = code_names.index(args.release)
+    if release_idx == 0:
+        logger.error(
+            "Release '%s' is the first release; "
+            "there is no preceding release to inherit from",
+            args.release,
+        )
+        sys.exit(1)
+
+    preceding = code_names[release_idx - 1]
+    logger.info("Preceding release: %s", preceding)
+
+    logger.debug("Loading features from %s", args.features)
+    features = load_json(args.features)
+
+    updated = 0
+    for feature in features:
+        changes = feature.get("changes")
+        if not changes:
+            continue
+
+        # Check if the release is already present in any change group.
+        already_present = any(
+            args.release in group["releases"] for group in changes
+        )
+        if already_present:
+            logger.debug("Feature '%s': release already present, skipping", feature["name"])
+            continue
+
+        # Find the change group that contains the preceding release.
+        target_group = None
+        for group in changes:
+            if preceding in group["releases"]:
+                target_group = group
+                break
+
+        if target_group is None:
+            logger.warning(
+                "Feature '%s' has no change group for preceding release '%s'",
+                feature["name"],
+                preceding,
+            )
+            continue
+
+        insort(target_group["releases"], args.release)
+        updated += 1
+        logger.info(
+            "Feature '%s': added to group with state=%s, comment='%s'",
+            feature["name"],
+            target_group["state"],
+            target_group["comment"],
+        )
+
+    save_json(args.features, features)
+    logger.info("Updated %d feature(s) in %s", updated, args.features)
+
+
+if __name__ == "__main__":
+    main()

--- a/security-features/security-features-tables.rst
+++ b/security-features/security-features-tables.rst
@@ -12,18 +12,26 @@
            - 22.04 LTS
            - 24.04 LTS
            - 25.10
+           - 26.04 LTS
+           - 26.10
          * - :ref:`Privilege restriction`
            - :ref:`AppArmor`
            - 3.0.4
            - 4.0.1
-           - 4.1.0
+           - 5.0.0
+           - 5.0.0
+           - 5.0.0
          * - :ref:`Privilege restriction`
            - :ref:`AppArmor unprivileged user namespace restrictions`
            - --
            - kernel & userspace
            - kernel & userspace
+           - kernel & userspace
+           - kernel & userspace
          * - :ref:`Privilege restriction`
            - :ref:`SELinux`
+           - universe
+           - universe
            - universe
            - universe
            - universe
@@ -32,8 +40,12 @@
            - kernel
            - kernel
            - kernel
+           - kernel
+           - kernel
          * - :ref:`Privilege restriction`
            - :ref:`PR_SET_SECCOMP`
+           - kernel
+           - kernel
            - kernel
            - kernel
            - kernel
@@ -42,8 +54,12 @@
            - kernel
            - kernel
            - kernel
+           - kernel
+           - kernel
          * - :ref:`Privilege restriction`
            - :ref:`Filesystem Capabilities`
+           - kernel & userspace (default on server)
+           - kernel & userspace (default on server)
            - kernel & userspace (default on server)
            - kernel & userspace (default on server)
            - kernel & userspace (default on server)
@@ -52,8 +68,12 @@
            - LUKS + TPM
            - LUKS + TPM
            - LUKS + TPM
+           - LUKS + TPM
+           - LUKS + TPM
          * - :ref:`Storage and filesystem`
            - :ref:`Encrypted LVM`
+           - main installer
+           - main installer
            - main installer
            - main installer
            - main installer
@@ -62,8 +82,12 @@
            - ZFS dataset encryption available, encrypted Home (eCryptfs) and ext4 encryption (fscrypt) available in universe
            - ZFS dataset encryption available, encrypted Home (eCryptfs) and ext4 encryption (fscrypt) available in universe
            - ZFS dataset encryption available, encrypted Home (eCryptfs) and ext4 encryption (fscrypt) available in universe
+           - ZFS dataset encryption available, encrypted Home (eCryptfs) and ext4 encryption (fscrypt) available in universe
+           - ZFS dataset encryption available, encrypted Home (eCryptfs) and ext4 encryption (fscrypt) available in universe
          * - :ref:`Network and firewalls`
            - :ref:`No Open Ports`
+           - policy
+           - policy
            - policy
            - policy
            - policy
@@ -72,8 +96,12 @@
            - kernel & sysctl
            - kernel & sysctl
            - kernel & sysctl
+           - kernel & sysctl
+           - kernel & sysctl
          * - :ref:`Network and firewalls`
            - :ref:`Firewall`
+           - ufw
+           - ufw
            - ufw
            - ufw
            - ufw
@@ -82,8 +110,12 @@
            - yescrypt
            - yescrypt
            - yescrypt
+           - yescrypt
+           - yescrypt
          * - :ref:`Cryptography`
            - :ref:`Cloud PRNG seed`
+           - pollinate
+           - pollinate
            - pollinate
            - pollinate
            - pollinate
@@ -92,8 +124,12 @@
            - policy
            - policy
            - policy
+           - policy
+           - policy
          * - :ref:`Process and memory protections`
            - :ref:`Symlink restrictions`
+           - kernel
+           - kernel
            - kernel
            - kernel
            - kernel
@@ -102,8 +138,12 @@
            - kernel
            - kernel
            - kernel
+           - kernel
+           - kernel
          * - :ref:`Process and memory protections`
            - :ref:`FIFO restrictions`
+           - kernel & sysctl
+           - kernel & sysctl
            - kernel & sysctl
            - kernel & sysctl
            - kernel & sysctl
@@ -112,8 +152,12 @@
            - kernel & sysctl
            - kernel & sysctl
            - kernel & sysctl
+           - kernel & sysctl
+           - kernel & sysctl
          * - :ref:`Process and memory protections`
            - :ref:`Stack Protector`
+           - gcc patch
+           - gcc patch
            - gcc patch
            - gcc patch
            - gcc patch
@@ -122,8 +166,12 @@
            - glibc
            - glibc
            - glibc
+           - glibc
+           - glibc
          * - :ref:`Process and memory protections`
            - :ref:`Pointer Obfuscation`
+           - glibc
+           - glibc
            - glibc
            - glibc
            - glibc
@@ -132,8 +180,12 @@
            - kernel
            - kernel
            - kernel
+           - kernel
+           - kernel
          * - :ref:`Process and memory protections`
            - :ref:`Libs/mmap ASLR`
+           - kernel
+           - kernel
            - kernel
            - kernel
            - kernel
@@ -142,8 +194,12 @@
            - kernel
            - kernel
            - kernel
+           - kernel
+           - kernel
          * - :ref:`Process and memory protections`
            - :ref:`brk ASLR`
+           - kernel
+           - kernel
            - kernel
            - kernel
            - kernel
@@ -152,8 +208,12 @@
            - kernel
            - kernel
            - kernel
+           - kernel
+           - kernel
          * - :ref:`Process and memory protections`
            - :ref:`Built as PIE`
+           - gcc patch (amd64, ppc64el, s390x), package list for others
+           - gcc patch (amd64, ppc64el, s390x), package list for others
            - gcc patch (amd64, ppc64el, s390x), package list for others
            - gcc patch (amd64, ppc64el, s390x), package list for others
            - gcc patch (amd64, ppc64el, s390x), package list for others
@@ -162,8 +222,12 @@
            - gcc patch
            - gcc patch
            - gcc patch
+           - gcc patch
+           - gcc patch
          * - :ref:`Process and memory protections`
            - :ref:`Built with RELRO`
+           - gcc patch
+           - gcc patch
            - gcc patch
            - gcc patch
            - gcc patch
@@ -172,8 +236,12 @@
            - gcc patch (amd64, ppc64el, s390x), package list for others
            - gcc patch (amd64, ppc64el, s390x), package list for others
            - gcc patch (amd64, ppc64el, s390x), package list for others
+           - gcc patch (amd64, ppc64el, s390x), package list for others
+           - gcc patch (amd64, ppc64el, s390x), package list for others
          * - :ref:`Process and memory protections`
            - :ref:`Built with -fstack-clash-protection`
+           - gcc patch (i386, amd64, ppc64el, s390x)
+           - gcc patch (i386, amd64, ppc64el, s390x)
            - gcc patch (i386, amd64, ppc64el, s390x)
            - gcc patch (i386, amd64, ppc64el, s390x)
            - gcc patch (i386, amd64, ppc64el, s390x)
@@ -182,8 +250,12 @@
            - gcc patch (i386, amd64)
            - gcc patch (i386, amd64)
            - gcc patch (i386, amd64)
+           - gcc patch (i386, amd64)
+           - gcc patch (i386, amd64)
          * - :ref:`Process and memory protections`
            - :ref:`Non-Executable Memory`
+           - PAE, ia32 partial-NX-emulation
+           - PAE, ia32 partial-NX-emulation
            - PAE, ia32 partial-NX-emulation
            - PAE, ia32 partial-NX-emulation
            - PAE, ia32 partial-NX-emulation
@@ -192,8 +264,12 @@
            - kernel
            - kernel
            - kernel
+           - kernel
+           - kernel
          * - :ref:`Process and memory protections`
            - :ref:`ptrace scope`
+           - kernel
+           - kernel
            - kernel
            - kernel
            - kernel
@@ -202,8 +278,12 @@
            - kernel
            - kernel
            - kernel
+           - kernel
+           - kernel
          * - :ref:`Process and memory protections`
            - :ref:`/dev/mem protection`
+           - kernel
+           - kernel
            - kernel
            - kernel
            - kernel
@@ -212,8 +292,12 @@
            - integrity only, no confidentiality
            - integrity only, no confidentiality
            - integrity only, no confidentiality
+           - integrity only, no confidentiality
+           - integrity only, no confidentiality
          * - :ref:`Kernel protections`
            - :ref:`/dev/kmem disabled`
+           - kernel
+           - kernel
            - kernel
            - kernel
            - kernel
@@ -222,8 +306,12 @@
            - sysctl
            - sysctl
            - sysctl
+           - sysctl
+           - sysctl
          * - :ref:`Kernel protections`
            - :ref:`Read-only data sections`
+           - kernel
+           - kernel
            - kernel
            - kernel
            - kernel
@@ -232,8 +320,12 @@
            - kernel
            - kernel
            - kernel
+           - kernel
+           - kernel
          * - :ref:`Kernel protections`
            - :ref:`Module RO/NX`
+           - kernel
+           - kernel
            - kernel
            - kernel
            - kernel
@@ -242,8 +334,12 @@
            - kernel
            - kernel
            - kernel
+           - kernel
+           - kernel
          * - :ref:`Kernel protections`
            - :ref:`Kernel Address Space Layout Randomisation`
+           - kernel (i386, amd64, arm64, and s390 only)
+           - kernel (i386, amd64, arm64, and s390 only)
            - kernel (i386, amd64, arm64, and s390 only)
            - kernel (i386, amd64, arm64, and s390 only)
            - kernel (i386, amd64, arm64, and s390 only)
@@ -252,8 +348,12 @@
            - kernel
            - kernel
            - kernel
+           - kernel
+           - kernel
          * - :ref:`Kernel protections`
            - :ref:`dmesg restrictions`
+           - kernel
+           - kernel
            - kernel
            - kernel
            - kernel
@@ -262,8 +362,12 @@
            - sysctl
            - sysctl
            - sysctl
+           - sysctl
+           - sysctl
          * - :ref:`Platform protections`
            - :ref:`UEFI Secure Boot`
+           - amd64, kernel signature enforcement
+           - amd64, kernel signature enforcement
            - amd64, kernel signature enforcement
            - amd64, kernel signature enforcement
            - amd64, kernel signature enforcement
@@ -272,8 +376,12 @@
            - kernel & userspace
            - kernel & userspace
            - kernel & userspace
+           - kernel & userspace
+           - kernel & userspace
          * - :ref:`Platform protections`
            - :ref:`usbauth`
+           - kernel & userspace
+           - kernel & userspace
            - kernel & userspace
            - kernel & userspace
            - kernel & userspace
@@ -282,8 +390,12 @@
            - kernel & userspace
            - kernel & userspace
            - kernel & userspace
+           - kernel & userspace
+           - kernel & userspace
          * - :ref:`Platform protections`
            - :ref:`thunderbolt-tools`
+           - kernel & userspace
+           - kernel & userspace
            - kernel & userspace
            - kernel & userspace
            - kernel & userspace
@@ -292,13 +404,19 @@
            - kernel & userspace (tpm-tools)
            - kernel & userspace (tpm-tools)
            - kernel & userspace (tpm-tools)
+           - kernel & userspace (tpm-tools)
+           - kernel & userspace (tpm-tools)
          * - :ref:`Security updates`
            - :ref:`Livepatch`
            - 22.04 LTS Kernel
            - 24.04 LTS Kernel
            - --
+           - 26.04 LTS Kernel
+           - --
          * - :ref:`Security updates`
            - :ref:`Automatic security updates`
+           - enabled
+           - enabled
            - enabled
            - enabled
            - enabled


### PR DESCRIPTION
- Regenerate security features docs for resolute and stonking
- Add script to help with adding new releases to `features.json`
    - By default, the script puts the new release in the same `changes` group as the previous release